### PR TITLE
Strict folding for folding.el + failsafe for other modes

### DIFF
--- a/fold-dwim-org.el
+++ b/fold-dwim-org.el
@@ -153,7 +153,10 @@ If not folding should occur. Then checks if we want strict folding, and if yes, 
                               (point)))
                       (and (boundp 'folding-mode)
                            folding-mode
-                           (integerp (folding-mark-look-at)))
+                           (let ((looking-at-mark (folding-mark-look-at)))
+                             (or (integerp looking-at-mark)
+                                 (eq looking-at-mark 'end)
+                                 (eq looking-at-mark 'end-in))))
                       (and (boundp 'TeX-fold-mode)
                            TeX-fold-mode
                            ;; FIXME : Add a test for strict folding here


### PR DESCRIPTION
Hey,

(Follow-up from https://github.com/mlf176f2/fold-dwim-org/issues/1 (sorry if there is a better way of doing this, not familiar enough with guthub yet).)

The function should-fold-p was still not called out of hs-minor-mode. I also improved the test for folding.el, it turns out there was a ready-to-use function for our test.

I also added the failsafe code I was suggesting for TeX-fold, outline-minor-mode and nxml, so that "strict" doesn't mean "disabled" for these modes.
