### PR TITLE
Outline and TeX-fold for latex-mode

### DIFF
--- a/fold-dwim-org.el
+++ b/fold-dwim-org.el
@@ -227,7 +227,7 @@ You can customize the key through `fold-dwim-org/trigger-key-block'."
   "Hide or show a block."
   (interactive)
   (save-excursion
-    (let ((last-point (or lst-point (point)))
+    (let* ((last-point (or lst-point (point)))
            (fold-dwim-org/minor-mode nil)
            (command (if key (key-binding key) nil))
            (other-keys fold-dwim-org/trigger-keys-block))

--- a/fold-dwim-org.el
+++ b/fold-dwim-org.el
@@ -149,8 +149,8 @@ If not folding should occur. Then checks if we want strict folding, and if yes, 
              (and fold-dwim-org-strict
                   (or (and (boundp 'hs-minor-mode) 
                            hs-minor-mode
-                           (= (point)
-                              (hs-find-block-beginning)))
+                           (= cur-point
+                              (or (hs-find-block-beginning) -1)))
                       (and (boundp 'folding-mode)
                            folding-mode
                            (let ((looking-at-mark (folding-mark-look-at)))
@@ -171,7 +171,7 @@ If not folding should occur. Then checks if we want strict folding, and if yes, 
                                     (point)
                                     )))
                              (eq (line-number-at-pos matching-begin)
-                                 (line-number-at-pos (point)))                               
+                                 (line-number-at-pos cur-point))                               
                              ))
                       (and (or outline-minor-mode
                                (eq major-mode 'outline-mode))

--- a/fold-dwim-org.el
+++ b/fold-dwim-org.el
@@ -161,8 +161,11 @@ If not folding should occur. Then checks if we want strict folding, and if yes, 
                            TeX-fold-mode
                            ;; FIXME : Add a test for strict folding here
                           )
-                      (and outline-minor-mode
-                           ;; FIXME : Add a test for strict folding here
+                      (and (or outline-minor-mode
+                               (eq major-mode 'outline-mode))
+                           (save-excursion
+                             (beginning-of-line)
+                             (looking-at outline-regexp))
                            )
                       (and (eq major-mode 'nxml-mode)
                            ;; FIXME : Add a test for strict folding here
@@ -224,7 +227,7 @@ You can customize the key through `fold-dwim-org/trigger-key-block'."
   "Hide or show a block."
   (interactive)
   (save-excursion
-    (let* ((last-point (or lst-point (point)))
+    (let ((last-point (or lst-point (point)))
            (fold-dwim-org/minor-mode nil)
            (command (if key (key-binding key) nil))
            (other-keys fold-dwim-org/trigger-keys-block))

--- a/fold-dwim-org.el
+++ b/fold-dwim-org.el
@@ -159,14 +159,18 @@ If not folding should occur. Then checks if we want strict folding, and if yes, 
                                  (eq looking-at-mark 'end-in))))
                       (and (boundp 'TeX-fold-mode)
                            TeX-fold-mode
-                           (eq (fold-dwim-auctex-env-or-macro) 'env) ;; No macros in strict mode
+                           (not (eq major-mode 'latex-mode)))
+                      (and (boundp 'TeX-fold-mode)
+                           TeX-fold-mode
+                           ;; No macros in strict mode (for latex at least)
+                           (eq (fold-dwim-auctex-env-or-macro) 'env)
                            (let ((matching-begin
                                   (save-excursion
                                     (case major-mode
-                                      ('context-mode (ConTeXt-find-matching-start))
-                                      ('texinfo-mode (Texinfo-find-env-start))
+                                      ;;('context-mode (ConTeXt-find-matching-start))
+                                      ;;('texinfo-mode (Texinfo-find-env-start))
                                       ('latex-mode (LaTeX-find-matching-begin))
-                                      (t nil) ;; Fallback for tex-mode
+                                      (t nil) 
                                       )
                                     (point)
                                     )))

--- a/fold-dwim-org.el
+++ b/fold-dwim-org.el
@@ -139,10 +139,11 @@
         (setq fold-dwim-org/last-point (point))
         (setq fold-dwim-org/last-txt (buffer-substring (point-at-bol) (point-at-eol)))))))
 
-(defun fold-dwim-org/should-fold-p (cur-point last-point)
+(defun fold-dwim-org/should-fold-p (last-point ref-point cur-point)
   "Checks to see if buffer has changed.
 If not folding should occur. Then checks if we want strict folding, and if yes, if we are at a folding mark."
   (save-excursion
+    (goto-char ref-point)
     (and (equal cur-point last-point)
          (or (not fold-dwim-org-strict)
              (and fold-dwim-org-strict
@@ -159,8 +160,20 @@ If not folding should occur. Then checks if we want strict folding, and if yes, 
                                  (eq looking-at-mark 'end-in))))
                       (and (boundp 'TeX-fold-mode)
                            TeX-fold-mode
-                           ;; FIXME : Add a test for strict folding here
-                          )
+                           (eq (fold-dwim-auctex-env-or-macro) 'env) ;; No macros in strict mode
+                           (let ((matching-begin
+                                  (save-excursion
+                                    (case major-mode
+                                      ('context-mode (ConTeXt-find-matching-start))
+                                      ('texinfo-mode (Texinfo-find-env-start))
+                                      ('latex-mode (LaTeX-find-matching-begin))
+                                      (t nil) ;; Fallback for tex-mode
+                                      )
+                                    (point)
+                                    )))
+                             (eq (line-number-at-pos matching-begin)
+                                 (line-number-at-pos (point)))                               
+                             ))
                       (and (or outline-minor-mode
                                (eq major-mode 'outline-mode))
                            (save-excursion
@@ -169,8 +182,7 @@ If not folding should occur. Then checks if we want strict folding, and if yes, 
                            )
                       (and (eq major-mode 'nxml-mode)
                            ;; FIXME : Add a test for strict folding here
-                           )
-                      ))))))
+                           )))))))
 (defun fold-dwim-org/hs-post ()
   "Post-command hook to hide/show if `fold-dwim-org/trigger-keys-block' is nil"
   (condition-case error
@@ -182,7 +194,7 @@ If not folding should occur. Then checks if we want strict folding, and if yes, 
                 (when (eq ?\t last-command-event)
                   (unless (and (fboundp 'yas/snippets-at-point)
                                (< 0 (length (yas/snippets-at-point 'all-snippets))))
-                    (when (fold-dwim-org/should-fold-p (point) fold-dwim-org/last-point)
+                    (when (fold-dwim-org/should-fold-p fold-dwim-org/last-point (point) (point))
                       (fold-dwim-org/toggle nil fold-dwim-org/last-point)))))))))
     (error
      (message "HS Org post-command hook error: %s" (error-message-string error)))))
@@ -226,7 +238,9 @@ You can customize the key through `fold-dwim-org/trigger-key-block'."
 (defun fold-dwim-org/toggle (&optional key lst-point)
   "Hide or show a block."
   (interactive)
-  (save-excursion
+  ;(save-excursion
+  ;; Did this excursion serve some purpose? It looks like it was just
+  ;; cancelling the fallback behavior of tab in some cases.
     (let* ((last-point (or lst-point (point)))
            (fold-dwim-org/minor-mode nil)
            (command (if key (key-binding key) nil))
@@ -240,8 +254,22 @@ You can customize the key through `fold-dwim-org/trigger-key-block'."
       (unless lst-point
         (if (commandp command)
             (call-interactively command)))
-      (when (fold-dwim-org/should-fold-p last-point (point))
-        (fold-dwim-toggle)))))
+      (let ((ref-point
+             ;; Workaround for cases when the point is at the beginning of the line
+             (save-excursion
+               (when fold-dwim-org-strict
+                   (progn
+                     (back-to-indentation)
+                     (and (not (looking-at-end-of-line))
+                          (forward-char 1))
+                     )
+                 )
+               (point))))
+        (when (fold-dwim-org/should-fold-p last-point ref-point (point))
+          (save-excursion
+            (goto-char ref-point)
+            (fold-dwim-toggle))))))
+  ;)
 
 (defun fold-dwim-org/hideshow-all (&optional key)
   "Hide or show all blocks."


### PR DESCRIPTION
Hello,

This is an attempt at getting outline and tex to work with fold-dwim.

Outline seems to be working, but indentation gets in the way when testing if the folding is really strict in outline-mode. Outline-minor-mode (for example in latex) seems to be working fine.

LaTeX is working, but I disabled folding of macros when using strict mode, as it would make little sense.
Context is even more of a pain, because fold-dwim-auctex-env-or-macro returns 'macro, when on a starting line. I'm not familiar enough with ConTeXt syntax to know if moving the point further around wouldn't break things.

I couldn't test texinfo because for some reason, indentation gets in the way. In doubt, I kept the fallback behavior.
I couldn't figure out a way to approach the problem for tex.
